### PR TITLE
Fix error reporting in RipROMs and main application.

### DIFF
--- a/c/RipROMs
+++ b/c/RipROMs
@@ -143,8 +143,8 @@ int main(void)
 
  in=fopen("<65Host$Dir>.!RunImage", "rb");
  if (!in) {
-   fprintf(stderr, "Failed to open !RunImage file in the !65Host directory. Please locate 65Host and try again.");
- return 2;
+   fprintf(stderr, "Failed to open !RunImage file in the !65Host directory. Please locate 65Host and try again.\n");
+   return 2;
  }
 
  fprintf(stderr, "Ripping BASIC\n\n");

--- a/c/main
+++ b/c/main
@@ -3174,6 +3174,7 @@ void windows(void)
 void init(void)
 {
   char cname[32];
+  _kernel_oserror *err;
 /*  nbytestogo = -1;
   nbytessent = -1;*/
   lquit = FALSE;
@@ -3200,7 +3201,13 @@ void init(void)
   regs.r[1] = 0x4B534154;
   regs.r[2] = (int)cname;
   regs.r[3] = (int)cusermessages;
-  _kernel_swi(Wimp_Initialise,&regs,&regs);
+  err = _kernel_swi(Wimp_Initialise,&regs,&regs);
+  if (err)
+  {
+    /* The system did not like the Wimp version, or otherwise failed. Report it. */
+    fprintf(stderr, "Failed to initialise Wimp: %s\n", err->errmess);
+    exit(1);
+  }
   wimp_version = regs.r[0];
   ntask = regs.r[1];
 


### PR DESCRIPTION
The RipROMs tool was failing to include a trailing '\n' when reporting a failure to find !65Host. It's now included.

The main application was ignoring the fact that the Wimp wasn't present and continued running blindly. We now check for this and report an error if the Wimp_Initialise fails.

I found these problems whilst trying to build and run it under RISC OS Pyromaniac - it built almost fine (understandable problems my end), but then running it had some oddities.