### PR TITLE
Applying vertical total adjust in full

### DIFF
--- a/c/scrmode
+++ b/c/scrmode
@@ -48,6 +48,22 @@ static int comparescreenmoderecords(SCREENMODERECORD *a, SCREENMODERECORD *b)
   return 0;
 }
 
+static int comparescreenmoderecordncolours(SCREENMODERECORD *a, SCREENMODERECORD *b)
+{
+  unsigned int nca = (unsigned int)a->ncolour;
+  unsigned int ncb = (unsigned int)b->ncolour;
+
+  if (nca == ncb)
+    return 0;
+
+  /*avoid 16 colour modes if possible as these are the most likely to be emulated modes*/
+  if (nca == 15) return -1;
+  if (ncb == 15) return 1;
+
+  if (nca > ncb) return -1;
+  return 1;
+}
+
 static int writemodevariables(int mode)
 {
   char buffer[128];
@@ -92,6 +108,7 @@ static void detectscreenmodesbyenumeration(int writeaction)
   char buffer[128];
   int modeblock[10];
   SCREENMODERECORD r,r2;
+  SCREENMODERECORD* insertionptr;
   char *cnext;
   int enumblock[32];
   int nallocated,ntoskip,nread;
@@ -241,13 +258,14 @@ static void detectscreenmodesbyenumeration(int writeaction)
       {
         do
         {
-          direction = comparescreenmoderecords(&screenmoderecords[insertionindex-1], &r);
+          insertionptr = &screenmoderecords[insertionindex-1];
+          direction = comparescreenmoderecords(insertionptr, &r);
           
           if (direction >= 0)
           {
-            if (direction == 0 && (unsigned int)screenmoderecords[insertionindex-1].ncolour > (unsigned int)r.ncolour)
+            if (direction == 0 && comparescreenmoderecordncolours(insertionptr, &r) < 0)
             {
-              screenmoderecords[insertionindex-1] = r;
+              *insertionptr = r;
             }
             break;
           }

--- a/c/video
+++ b/c/video
@@ -3506,7 +3506,7 @@ void videoscanline(void)
   /*increase 6845 scanline count by 1*/
   m6845_sc++;
 
-  if (m6845_sc >= m6845_sl)
+  if (m6845_sc >= m6845_sl && m6845_vc < m6845_vt)
   {
     /*scanline count >= scan lines per character row*/
     m6845_vc++;


### PR DESCRIPTION
BeebIt currently truncates the 6845 vertical total adjust when it is greater than the number of scanlines per character. This leads to shortfalls that make the display in Tricky's AstroBlaster judder up and down. This branch contains a change to apply the vertical total adjust in full. This branch also contains a general change to the screen mode enumeration with the specific intention of avoiding Aemulor low colour mode on PineBook Pro.