### PR TITLE
Changes for BeebIt 0.78

### DIFF
--- a/!Help
+++ b/!Help
@@ -1,4 +1,4 @@
-BeebIt : Version 0.77 (02 Nov 2024)
+BeebIt : Version 0.78 (12 Jul 2025)
 ===================================
 Emulator by Michael Foot <mjfoot.nz@gmail.com>.
 Additions by James Lampard.

--- a/c/1770fdc
+++ b/c/1770fdc
@@ -99,13 +99,12 @@ int w1770_side;
 int w1770_density;
 int w1770_timer;
 int w1770_byteinsector;
-int w1770_initialised; /*for the B+*/
 int w1770_writegate;
 int w1770_lastbyte;
 
 void w1770reset(void)
 {
-  w1770_controlreg = 0;
+  w1770_controlreg = 1;
   w1770_statusreg = 0;
   w1770_trackreg = w1770_track = 0;
   w1770_sectorreg = 0;
@@ -116,7 +115,6 @@ void w1770reset(void)
   w1770_timer = 0;
   w1770_lastbyte = FALSE;
   w1770_writegate = FALSE;
-  w1770_initialised = FALSE;
 }
 
 /*void w1770setnmi(char nvalue)

--- a/c/6845crtc
+++ b/c/6845crtc
@@ -26,6 +26,8 @@
 char m6845_r[18]; /*18 registers*/
 int m6845_vt;
 int m6845_sl;
+int m6845_slplus;
+int m6845_scstep;
 int m6845_vd;
 int m6845_hsp;
 int m6845_vsp;
@@ -39,6 +41,7 @@ int m6845_rightoffscreen;
 int m6845_leftextra; /*extra pixels on the left*/
 int m6845_rightextra; /*extra pixels on the right*/
 int m6845_interlaceon;
+int m6845_interlacesl;
 int m6845_displayskew;
 int m6845_cursorskew;
 int m6845_addressreg;
@@ -256,8 +259,11 @@ void crtcwrite(int naddress,int nvalue)
       /* 1  0=Two character delay*/
       /* 1  1=Disable cursor output*/
       m6845_interlaceon = (nvalue & 0x01);
+      m6845_interlacesl = (nvalue & 0x03) == 0x03;
       m6845_displayskew = (nvalue & 0x30)>>4;
       m6845_cursorskew = (nvalue & 0xC0)>>6;
+      m6845_scstep = m6845_interlacesl+1;
+      m6845_slplus = m6845_sl+m6845_scstep;
       /*if (!m6845_interlaceon)
         video_field = 0;*/
       video_display = (video_de AND m6845_displayskew != 3);
@@ -277,7 +283,8 @@ void crtcwrite(int naddress,int nvalue)
     case 9:
       /*5 bit*/
       /*number of scan lines per character row*/
-      m6845_sl = (nvalue & 0x1F)+1;
+      m6845_sl = (nvalue & 0x1F);
+      m6845_slplus = m6845_sl+m6845_scstep;
       crtcvertical();
       break;
     case 10:
@@ -468,7 +475,7 @@ void crtcwidthextra(void)
 
 void crtchorizontal(void)
 {
-  if (videoula_clockrate OR lteletextmode)
+  if (videoula_clockrate)
     /*fast clock mode (2MHz cycles) */
     m6845_horizontaltotal = (m6845_r[0x00] + 1);
   else
@@ -478,19 +485,19 @@ void crtchorizontal(void)
 
 void crtcvertical(void)
 {
-  if ((m6845_vd*m6845_sl) == MODE12_Y)
-    video_display0 = ((m6845_vt-m6845_vsp)*m6845_sl)+m6845_adj/*-m6845_vsw*/;
+  if ((m6845_vd*m6845_slplus) == MODE12_Y)
+    video_display0 = ((m6845_vt-m6845_vsp)*m6845_slplus)+m6845_adj/*-m6845_vsw*/;
   else
   {
     /*MODES 3,6*/
-    if ((m6845_vd*m6845_sl) == 250)
+    if ((m6845_vd*m6845_slplus) == 250)
       /*Botch for Master Compact Modes 3 and 6*/
-      video_display0 = ((m6845_vt-m6845_vsp)*m6845_sl)+m6845_adj/*-m6845_vsw*/;
+      video_display0 = ((m6845_vt-m6845_vsp)*m6845_slplus)+m6845_adj/*-m6845_vsw*/;
     else
       video_display0 = 32;
     /*video_display0 = 32+((MODE12_Y-(m6845_vd*m6845_sl)+m6845_adj)/2);*/
   }
-  video_display1 = video_display0+MODE12_Y; /*(m6845_vd*m6845_sl)+m6845_adj;*/
+  video_display1 = video_display0+MODE12_Y; /*(m6845_vd*m6845_slplus)+m6845_adj;*/
   video_totalend = ((m6845_vt << 8) | m6845_adj);
 
 /*    bbcvdu(32);

--- a/c/beebit
+++ b/c/beebit
@@ -982,7 +982,6 @@ void beebitpoll(void)
         beebit_rommodified = FALSE;
         systemviareset(FALSE);
         userviareset(FALSE);
-        w1770_initialised = FALSE; /*for the B+*/
         sheilareset();
         /*videoulareset(FALSE);*/
         i8271reset();

--- a/c/beebit
+++ b/c/beebit
@@ -530,6 +530,7 @@ int beebitenter(void)
   /*char *n;*/
   /*int nicon[0x10] = {49,46,43,40,37,34,31,28,25,22,19,16,13,10,7,4};*/
   int i, lredraw, nmask, nindex;
+  I8271_REMOVED_DATA discremoveddata;
   FILE *hfile;
 
   lexit = FALSE;
@@ -586,6 +587,7 @@ int beebitenter(void)
     }
     beebit_rommask = 0;
     /*disc images*/
+    memcpy(discremoveddata, i8271_data, sizeof(I8271_REMOVED_DATA));
     for (i=0;i<=3;i++)
     {
       if (strlen(beebit_discimage[i]) > 1)
@@ -605,6 +607,7 @@ int beebitenter(void)
       else
         beebit_driveimage[i] = 0;
     }
+    memcpy(i8271_data, discremoveddata, sizeof(I8271_REMOVED_DATA));
     if (beebit_imagetype[0] == DFS_DSD_TRACK OR beebit_imagetype[0] == DFS_DSD_SIDE OR beebit_imagetype[0] == ADFS_INTERLEAVED)
       beebit_imagetype[2] = beebit_imagetype[0];
     if (beebit_imagetype[1] == DFS_DSD_TRACK OR beebit_imagetype[1] == DFS_DSD_SIDE OR beebit_imagetype[0] == ADFS_INTERLEAVED)

--- a/c/main
+++ b/c/main
@@ -15,7 +15,7 @@
 /* DEFINES */
 
 #define APP_NAME "BeebIt"
-#define APP_VERSION "0.77"
+#define APP_VERSION "0.78"
 
 #define Wimp_GetMenuState 0x0400F4
 

--- a/c/sheila
+++ b/c/sheila
@@ -658,10 +658,7 @@ void sheilawrite_b(int naddress, char nvalue)
       videoulawrite(naddress, nvalue);
       break;
     case 0x30:
-    case 0x34:
-    case 0x38:
-    case 0x3C:
-      /*&FE30 - &FE3F (ROMSEL)*/
+      /*&FE30 - &FE33 (ROMSEL)*/
       #ifdef __DEVELOPxx__
         fprintf(htrace,"ROMSEL(&%X,&%X)",naddress,nvalue);
       #endif
@@ -673,6 +670,18 @@ void sheilawrite_b(int naddress, char nvalue)
       #ifdef __DEVELOPxx__
         fprintf(htrace,"=&%X\n",beebit_romsel);
       #endif
+      break;
+    case 0x34:
+      /*&FE34 - &FE37 (ROMSEL in place of ACCCON)*/
+      /*ignoring writes directed at B+ or Master*/
+      break;
+    case 0x38:
+      /*&FE38 - &FE3B (ROMSEL in place of INTOFF)*/
+      /*ignoring writes directed at Master*/
+      break;
+    case 0x3C:
+      /*&FE3C - &FE3F (ROMSEL in place of INTON)*/
+      /*ignoring writes directed at Master*/
       break;
     case 0x40:
     case 0x44:

--- a/c/sheila
+++ b/c/sheila
@@ -361,15 +361,10 @@ char sheilaread_bp(int naddress)
     case 0x98:
     case 0x9C:
       /*&FE80-&FE9F (8271 or 1770)*/
-      if ((naddress & 0xFF) == 0x80)
-        nresult = w1770controlread();
-      else if ((naddress & 0xFF) == 0x85 AND !w1770_initialised)
-      {
-        nresult = w1770controlread();
-        w1770_initialised = TRUE;
-      }
-      else
+      if (naddress & 0x04)
         nresult = w1770read(naddress);
+      else
+        nresult = w1770controlread();
       break;
     case 0xA0:
     case 0xA4:
@@ -933,12 +928,10 @@ void sheilawrite_bp(int naddress, char nvalue)
     case 0x98:
     case 0x9C:
       /*&FE80 - &FE9F (8271 or 1770)*/
-      if ((naddress & 0xFF) == 0x80)
-        w1770controlwrite(nvalue);
-      else if ((naddress & 0xFF) == 0x85 AND !w1770_initialised)
-        w1770controlwrite(nvalue);
-      else
+      if (naddress & 0x04)
         w1770write(naddress,nvalue);
+      else
+        w1770controlwrite(nvalue);
       break;
     case 0xC0:
     case 0xC4:

--- a/c/video
+++ b/c/video
@@ -552,6 +552,7 @@ void videoreset(int lfull)
   video_field = 0;
   video_drawline = 0;
   nclock = clock()+TIME_50HZ;
+  m6845_scstep = 1;
   m6845_vc = 0; /*m6845_vsp;*/
   m6845_sc = -1;
   video_currentrow = 0;
@@ -3510,9 +3511,11 @@ void videoscanline(void)
   video_scanline++;
 
   /*increase 6845 scanline count by 1*/
-  m6845_sc++;
+  /*m6845_sc++;*/
+  m6845_sc += m6845_scstep;
 
-  if (m6845_sc >= m6845_sl && m6845_vc < m6845_vt)
+  /*if (m6845_sc >= m6845_sl && m6845_vc < m6845_vt)*/
+  if (m6845_sc >= m6845_slplus && m6845_vc < m6845_vt)
   {
     /*scanline count >= scan lines per character row*/
     m6845_vc++;

--- a/h/1770fdc
+++ b/h/1770fdc
@@ -20,7 +20,6 @@
 #define ADFS_NON_INTERLEAVED 0x10 /*non interleaved*/
 #define ADFS_INTERLEAVED 0x11 /*interleaved*/
 
-extern int w1770_initialised;
 extern int w1770_timer;
 
 extern void w1770reset(void);

--- a/h/6845crtc
+++ b/h/6845crtc
@@ -13,6 +13,8 @@
 extern char m6845_r[18]; /*18 registers*/
 extern int m6845_vt;
 extern int m6845_sl;
+extern int m6845_slplus;
+extern int m6845_scstep;
 extern int m6845_vd;
 extern int m6845_hsp;
 extern int m6845_vsp;
@@ -26,6 +28,7 @@ extern int m6845_rightoffscreen;
 extern int m6845_leftextra; /*extra pixels on the left*/
 extern int m6845_rightextra; /*extra pixels on the right*/
 extern int m6845_interlaceon;
+extern int m6845_interlacesl;
 extern int m6845_displayskew;
 extern int m6845_cursorskew;
 extern int m6845_addressreg;

--- a/h/8271fdc
+++ b/h/8271fdc
@@ -20,6 +20,8 @@
 #define ADFS_NON_INTERLEAVED 0x10 /*non interleaved*/
 #define ADFS_INTERLEAVED 0x11 /*interleaved*/
 
+typedef char I8271_REMOVED_DATA[ADFS_SECTOR_SIZE > DFS_SECTOR_SIZE ? ADFS_SECTOR_SIZE : DFS_SECTOR_SIZE];
+
 /*Intel 8271*/
 /*extern int i8271_writeprotect[2];*/
 extern char i8271_commandreg;

--- a/s/riscos
+++ b/s/riscos
@@ -349,6 +349,10 @@ keyupdown3
   MOV r8,#&FF
   STRB r8,[r11,r9] ;set status to &FF
 
+  ;check for <Shift> and <Ctrl>
+  CMP r9,#&01
+  LDMLSFD sp!,{r0-r3,r8-r12,pc} ;if shift or ctrl, exit
+
   ;CMP r9,#&50 ;shift lock
   ;BNE keyupdown4
 


### PR DESCRIPTION
This branch contains a set of small fixes for BeebIt.
- Fixed improved detection of floppy disc images. The 8271 FDC data buffer is not disrupted.
- Fixed scanline counting in teletext mode. Corrects the number of cycles per frame.
- ROMSEL writes in the B+/Master ACCCON range are ignored in B mode, as in Version 0.76.
- Stopped keys and mouse buttons mapped to Shift or Ctrl triggering a keyboard interrupt.
- Simplified the way the 1770 FDC is detected by B+ DFS.