### PR TITLE
Changes for BeebIt 0.79

### DIFF
--- a/!Help
+++ b/!Help
@@ -1,4 +1,4 @@
-BeebIt : Version 0.78 (12 Jul 2025)
+BeebIt : Version 0.79 (04 Jan 2026)
 ===================================
 Emulator by Michael Foot <mjfoot.nz@gmail.com>.
 Additions by James Lampard.

--- a/c/main
+++ b/c/main
@@ -15,7 +15,7 @@
 /* DEFINES */
 
 #define APP_NAME "BeebIt"
-#define APP_VERSION "0.78"
+#define APP_VERSION "0.79"
 
 #define Wimp_GetMenuState 0x0400F4
 

--- a/c/video
+++ b/c/video
@@ -328,6 +328,7 @@ void videosetscale(void)
     videographicsscale = NULL;
     videoteletextscale = NULL;
   }
+  nclock = clock();
 }
 
 void videosetplot(void)
@@ -551,7 +552,7 @@ void videoreset(int lfull)
   /*video_phase = VIDEO_DRAWWAIT;*/
   video_field = 0;
   video_drawline = 0;
-  nclock = clock()+TIME_50HZ;
+  nclock = clock();
   m6845_scstep = 1;
   m6845_vc = 0; /*m6845_vsp;*/
   m6845_sc = -1;
@@ -3504,6 +3505,7 @@ void videoscanline(void)
   int naddress,localrow,nscaledscreen;
   int displaycursorx,displaycursorwidth;
   int charstodisplayline;
+  int clockdiff;
 
   /*---counter---*/
 
@@ -3669,11 +3671,15 @@ void videoscanline(void)
       /*sync emulated BBC clock with PC clock*/
       if (beebit_cpuspeed == CPU_2MHZ)
       {
-        vsync(); /*wait for native scren vsync*/
-        while (clock() < nclock)
+        nclock += TIME_50HZ;
+        clockdiff = (int)(nclock - clock());
+        while (clockdiff >= 5)
         {
+          vsync(); /*wait for native screen vsync*/
+          clockdiff = (int)(nclock - clock());
         }
-        nclock = clock()+TIME_50HZ;
+        if (clockdiff < -25)
+          nclock += (-25 - clockdiff);
       }
       /*}*/
     }

--- a/s/riscos
+++ b/s/riscos
@@ -242,10 +242,12 @@ inttohexb
   LDR r11,=keylookup
   LDRB r9,[r11,r2] ;get bbc key code
 
-  ;check for <Break>
-  ;CMP r2,#&0F ;Break
-  CMP r9,#&80
-  BNE keyupdownF12
+  ;check for RISC OS <Break>
+  CMP r2,#&0F ;Break
+  CMPEQ r1,#1 ;and key is down
+  BNE keyupdownForBreak
+
+  MOV r8,r1
 
   ;STR lr,[sp, #-4]!  ;STMFD sp!,{lr}
   MOV r0,#129 ;scan kbd for single key
@@ -255,7 +257,7 @@ inttohexb
   ;LDR lr, [sp], #4   ;LDMFD sp!,{lr}
 
   TEQ r1,#&FF ;pressed?
-  LDMEQFD sp!,{r0-r3,r8-r12,pc} ;yes pass event on for watchdog.
+  LDMEQFD sp!,{r0-r3,r8-r12,pc} ;yes ignore event intended for watchdog.
 
   ;STR lr,[sp, #-4]!  ;STMFD sp!,{lr}
   MOV r0,#129 ;scan kbd for single key
@@ -265,7 +267,14 @@ inttohexb
   ;LDR lr, [sp], #4   ;LDMFD sp!,{lr}
 
   TEQ r1,#&FF ;pressed?
-  LDMEQFD sp!,{r0-r3,r8-r12,pc} ;yes pass event on for watchdog.
+  LDMEQFD sp!,{r0-r3,r8-r12,pc} ;yes ignore event intended for watchdog.
+
+  MOV r1,r8
+  MOV r2,#&0F
+
+keyupdownForBreak
+  CMP r9,#&80 ;Check for key mapped to Break
+  BNE keyupdownF12
 
   MOV r9,#&FF
   LDR r11,=lbreak


### PR DESCRIPTION
This branch contains two more fixes for BeebIt (the third fix is packaged in !BeebIt).

- Modified the 2 MHz speed option to suit short idle times. This stops it settling on a lower speed on RiscPC.
- Limited the Alt-Break check in the key handler. It now covers the RISC OS Break key, not every key mapped to Break.
- BeebIt64K is now 32 bit compatible.